### PR TITLE
fix(actions): add a warning

### DIFF
--- a/.github/workflows/_reusable_merge_upstream.yml
+++ b/.github/workflows/_reusable_merge_upstream.yml
@@ -85,5 +85,5 @@ jobs:
           --base ${{ steps.upstream-branch.outputs.ref }}
           --assignee ${{ steps.assignee.outputs.login || github.actor }}
           --title "[merge] ${{ github.ref_name}} into ${{ steps.upstream-branch.outputs.ref }}"
-          --body "Merge Pull request opened automatically. Use Merge Pull Request action (DO NOT SQUASH).")
+          --body "Merge Pull request opened automatically. Use Merge Pull Request action (DO NOT SQUASH). DO NOT commit conflict resolution update to the base branch (default option in Github UI).")
           && echo "pr-url=$pr_url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_reusable_merge_upstream.yml
+++ b/.github/workflows/_reusable_merge_upstream.yml
@@ -85,5 +85,5 @@ jobs:
           --base ${{ steps.upstream-branch.outputs.ref }}
           --assignee ${{ steps.assignee.outputs.login || github.actor }}
           --title "[merge] ${{ github.ref_name}} into ${{ steps.upstream-branch.outputs.ref }}"
-          --body "Merge Pull request opened automatically. Use Merge Pull Request action (DO NOT SQUASH). DO NOT commit conflict resolution update to the base branch (default option in Github UI).")
+          --body "Merge Pull request opened automatically. Use Merge Pull Request action (DO NOT SQUASH).\nDO NOT commit conflict resolution update to the base branch (default option in Github UI).")
           && echo "pr-url=$pr_url" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Committing the conflict resolution to the base branch is the default option in Github UI. But in the case of merge PR, this option has catastrophic consequences and must not be used.