### PR TITLE
ci(merge-upstream): notify on slack if PR creation failed

### DIFF
--- a/.github/workflows/_reusable_merge_upstream.yml
+++ b/.github/workflows/_reusable_merge_upstream.yml
@@ -6,11 +6,19 @@ on:
       ignore-conflicts:
         type: boolean
         default: false
+      skip-slack-notification:
+        type: boolean
+        default: false
+      slack-channel-id:
+        type: string
+        default: ${{ vars.RD_PLATFORM_SLACK_CHANNEL_ID }}
+
     secrets:
-     KSM_CONFIG:
-      required: true
-     BONITA_CI_PAT:
-      required: true
+      KSM_CONFIG:
+        required: true
+      BONITA_CI_PAT:
+        required: true
+
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -35,19 +43,19 @@ jobs:
           token: ${{ secrets.BONITA_CI_PAT }}
 
       - name: Configure git merge.ours.driver
-        if:  ${{ inputs.ignore-conflicts }}
+        if: ${{ inputs.ignore-conflicts }}
         run: git config merge.ours.driver true
 
       - name: Merge upstream branch
         run: |
-           git merge origin/${{ github.ref_name }} ${{ inputs.ignore-conflicts && '-X ours' || ''}}  -m "chore(merge): ${{ github.ref_name }} into ${{ steps.upstream-branch.outputs.ref }}"
-           git push
+          git merge origin/${{ github.ref_name }} ${{ inputs.ignore-conflicts && '-X ours' || ''}}  -m "chore(merge): ${{ github.ref_name }} into ${{ steps.upstream-branch.outputs.ref }}"
+          git push
 
   create-merge-pr-in-conflict:
     needs: merge-in-upstream-branch
     if: failure()
     runs-on: ubuntu-22.04
-    permissions: 
+    permissions:
       pull-requests: write
       contents: write
       actions: read
@@ -101,3 +109,15 @@ jobs:
           --title "[merge] ${{ github.ref_name}} into ${{ steps.upstream-branch.outputs.ref }}"
           --body "Merge Pull request opened automatically. Use `Merge Pull Request` action (DO NOT SQUASH). DO NOT commit conflict resolution update to the base branch (default option in Github UI).")
           && echo "pr-url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Notify failure on Slack
+        if: ${{ failure() && !inputs.skip-slack-notification }}
+        uses: bonitasoft/notify-slack-action@v1
+        with:
+          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
+          channel-id: ${{ inputs.slack-channel-id }}
+          message: |
+            :fire: Failed to create the merge conflict Pull Request on `${{ github.repository }}` from `${{ github.ref_name }}` to `${{ steps.upstream-branch.outputs.ref }}`
+
+            - Add a :fire_extinguisher: if you take the action to resolve the problem
+            - Add a :sweat_drops: when it's done


### PR DESCRIPTION
Sometimes, the step that creates the merge conflict PR fails. We need the whole team to be notified so that someone can resolve the problem.

The default channel is the `#rd-platform` but it can be changed using the input `slack-channel-id`

Also, the notification can be skipped using the input `skip-slack-notification` if needed.