### PR TITLE
fix(subtree): use splitsh-lite v1.0.1 which has pre-built binaries

### DIFF
--- a/.github/workflows/_reusable_push_to_subtree.yml
+++ b/.github/workflows/_reusable_push_to_subtree.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install splitsh-lite
         run: |
-          curl -L https://github.com/splitsh/lite/releases/download/v2.0.0/lite_linux_amd64.tar.gz | tar -xz
+          curl -L https://github.com/splitsh/lite/releases/download/v1.0.1/lite_linux_amd64.tar.gz | tar -xz
           sudo mv splitsh-lite /usr/local/bin/
 
       # Inspired by https://github.com/claudiodekker/splitsh-action


### PR DESCRIPTION
## Summary
- Use splitsh-lite v1.0.1 instead of v2.0.0
- v2.0.0 has no pre-built binaries (empty release assets)
- v1.0.1 has the `lite_linux_amd64.tar.gz` binary

## Context
Follow-up fix to #16 which introduced the native splitsh-lite implementation but used v2.0.0 which doesn't have pre-built binaries.

## Test plan
- [ ] Re-run the failing workflows after merging to verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)