### PR TITLE
fix(subtree): add persist-credentials false for checkout v6 compatibility

### DIFF
--- a/.github/workflows/_reusable_push_to_subtree.yml
+++ b/.github/workflows/_reusable_push_to_subtree.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
+          # Required: checkout v6 sets up credentials that override token-embedded URLs
+          persist-credentials: false
 
       - name: Install splitsh-lite
         run: |


### PR DESCRIPTION
## Summary
- Fixes permission denied error when pushing to subtree repositories
- checkout v6 stores credentials via `includeIf.gitdir` entries that override token-embedded URLs
- Setting `persist-credentials: false` prevents this, allowing the PAT to authenticate correctly

Refs #17

## Test plan
- [x] Tested on bonita-migration-sp repository - push to subtree now works

🤖 Generated with [Claude Code](https://claude.com/claude-code)